### PR TITLE
Feature/semi lazy loading strategy

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "arrowParens": "avoid",
+  "trailingComma": "none"
+}

--- a/projects/demo/src/app/pages/home/home.component.html
+++ b/projects/demo/src/app/pages/home/home.component.html
@@ -151,7 +151,7 @@
   let-index="index"
   let-selectedIndex="selectedIndex"
   let-item="item"
-  let-visited="visited"
+  let-seen="seen"
 >
   <ng-container *ngIf="item.video; then videoTemplate; else imgTemplate">
   </ng-container>
@@ -159,10 +159,10 @@
     <img
       #img
       class="custom-media"
-      [src]="visited ? item.src : ''"
+      [src]="seen ? item.src : ''"
       (load)="onImageLoad()"
     />
-    <div class="custom-loading" *ngIf="visited && img.naturalHeight <= 0">
+    <div class="custom-loading" *ngIf="seen && img.naturalHeight <= 0">
       Custom item loading ...
     </div>
   </ng-template>
@@ -170,7 +170,7 @@
     <video
       #video
       class="custom-media"
-      [src]="visited ? item.src : ''"
+      [src]="seen ? item.src : ''"
       controls
       (loadedmetadata)="onImageLoad()"
     ></video>

--- a/projects/gallery/src/lib/components/image-viewer/image-viewer.component.html
+++ b/projects/gallery/src/lib/components/image-viewer/image-viewer.component.html
@@ -22,7 +22,7 @@
         *ngIf="!isYoutube(item) && !item.video"
         [src]="getSrc(item)"
         [alt]="item.alt"
-        [class.loading]="item._visited && !item._loaded"
+        [class.loading]="item._seen && !item._loaded"
         [style.objectFit]="objectFit"
         (load)="onItemLoaded(item, $event)"
         (error)="onItemErrored(item, $event)"
@@ -31,7 +31,7 @@
       <video
         *ngIf="!isYoutube(item) && item.video"
         [src]="getSrc(item)"
-        [class.loading]="item._visited && !item._loaded"
+        [class.loading]="item._seen && !item._loaded"
         [style.objectFit]="objectFit"
         controls
         playsinline
@@ -47,7 +47,7 @@
         (load)="onItemLoaded(item, $event)"
       ></iframe>
 
-      <ng-container *ngIf="item._visited && !item._loaded && !item._failed">
+      <ng-container *ngIf="item._seen && !item._loaded && !item._failed">
         <ng-container *ngTemplateOutlet="loadingTemplate"></ng-container>
       </ng-container>
 
@@ -67,7 +67,7 @@
             index: i,
             selectedIndex: selectedIndex,
             item: item,
-            visited: item._visited
+            seen: item._seen
           }
         "
       ></ng-container>

--- a/projects/gallery/src/lib/components/image-viewer/image-viewer.component.ts
+++ b/projects/gallery/src/lib/components/image-viewer/image-viewer.component.ts
@@ -135,7 +135,6 @@ export class ImageViewerComponent implements OnChanges, OnInit, OnDestroy {
 
   ngOnChanges({ thumbsOrientation, items }: SimpleChanges) {
     if (thumbsOrientation && !thumbsOrientation.firstChange) {
-      // if image-viewer - thumbnails layout (main axis) changed from vertical to horizontal or vice versa
       if (!(thumbsOrientation.currentValue & thumbsOrientation.previousValue)) {
         requestAnimationFrame(() => {
           this.itemWidth = this.getItemWidth();
@@ -143,7 +142,6 @@ export class ImageViewerComponent implements OnChanges, OnInit, OnDestroy {
         });
       }
     }
-    // late initialization; in case the gallery items come later
     if (items && items.currentValue) {
       this.onResize();
       this.observeSeenItems();
@@ -363,6 +361,7 @@ export class ImageViewerComponent implements OnChanges, OnInit, OnDestroy {
     if (isBrowser && SUPPORT.intersectionObserver) {
       this.seenItemsObserver.disconnect();
 
+      // wait for any rendering changes necessary
       setTimeout(() => {
         this.itemsRef.forEach(ref =>
           this.seenItemsObserver.observe(ref.nativeElement)

--- a/projects/gallery/src/lib/components/image-viewer/image-viewer.component.ts
+++ b/projects/gallery/src/lib/components/image-viewer/image-viewer.component.ts
@@ -276,7 +276,7 @@ export class ImageViewerComponent implements OnChanges, OnInit, OnDestroy {
   }
 
   getSrc(item: GalleryItemInternal) {
-    return this.lazyLoading && !item._visited ? '' : item.src;
+    return this.lazyLoading && !item._seen ? '' : item.src;
   }
 
   isYoutube(item: GalleryItemInternal) {
@@ -380,7 +380,7 @@ export class ImageViewerComponent implements OnChanges, OnInit, OnDestroy {
           .toArray()
           .findIndex(i => i.nativeElement === target);
 
-        this.items[index]._visited = true;
+        this.items[index]._seen = true;
         this.cd.detectChanges();
         this.seenItemsObserver.unobserve(target);
       });

--- a/projects/gallery/src/lib/components/image-viewer/image-viewer.component.ts
+++ b/projects/gallery/src/lib/components/image-viewer/image-viewer.component.ts
@@ -26,7 +26,8 @@ import {
   UA,
   VerticalOrientation,
   OrientationFlag,
-  ItemTemplateContext
+  ItemTemplateContext,
+  SUPPORT
 } from '../../core';
 import { GalleryItemInternal } from '../../core/gallery-item';
 import { ImageClickEvent } from './image-viewer.model';
@@ -101,6 +102,7 @@ export class ImageViewerComponent implements OnChanges, OnInit, OnDestroy {
   imagesHidden = true;
   noAnimation = false;
 
+  private seenItemsObserver: IntersectionObserver;
   private destroy$ = new Subject();
 
   private itemWidth: number;
@@ -144,7 +146,7 @@ export class ImageViewerComponent implements OnChanges, OnInit, OnDestroy {
     // late initialization; in case the gallery items come later
     if (items && items.currentValue) {
       this.onResize();
-      setTimeout(() => this.markAsVisitedIfNeeded(this.selectedIndex));
+      this.observeSeenItems();
     }
   }
 
@@ -259,11 +261,18 @@ export class ImageViewerComponent implements OnChanges, OnInit, OnDestroy {
         });
       });
     }
+
+    if (isBrowser && SUPPORT.intersectionObserver) {
+      this.seenItemsObserver = new IntersectionObserver(this.onItemsSeen, {
+        threshold: 0.1
+      });
+    }
   }
 
   ngOnDestroy() {
     this.destroy$.next(null);
     this.destroy$.complete();
+    this.seenItemsObserver.disconnect();
   }
 
   getSrc(item: GalleryItemInternal) {
@@ -310,8 +319,6 @@ export class ImageViewerComponent implements OnChanges, OnInit, OnDestroy {
       }
     }
 
-    this.markAsVisitedIfNeeded(index);
-
     this.selectedIndex = index;
     this.selection.emit(index);
     this.center();
@@ -352,13 +359,31 @@ export class ImageViewerComponent implements OnChanges, OnInit, OnDestroy {
     return this.hostRef.nativeElement.querySelector('li').offsetWidth;
   }
 
-  private markAsVisitedIfNeeded(index: number) {
-    const item = this.items[index];
-    if (!item._visited) {
-      item._visited = true;
-      this.cd.markForCheck();
+  private observeSeenItems() {
+    if (isBrowser && SUPPORT.intersectionObserver) {
+      this.seenItemsObserver.disconnect();
+
+      setTimeout(() => {
+        this.itemsRef.forEach(ref =>
+          this.seenItemsObserver.observe(ref.nativeElement)
+        );
+      });
     }
   }
+
+  private onItemsSeen: IntersectionObserverCallback = entries =>
+    entries
+      .filter(e => e.isIntersecting && e.intersectionRatio > 0)
+      .forEach(e => {
+        const target = e.target as HTMLElement;
+        const index = this.itemsRef
+          .toArray()
+          .findIndex(i => i.nativeElement === target);
+
+        this.items[index]._visited = true;
+        this.cd.detectChanges();
+        this.seenItemsObserver.unobserve(target);
+      });
 
   private onResize = () => {
     requestAnimationFrame(() => {

--- a/projects/gallery/src/lib/core/gallery-item.ts
+++ b/projects/gallery/src/lib/core/gallery-item.ts
@@ -38,9 +38,9 @@ export interface GalleryItemInternal extends GalleryItem {
   _loaded?: boolean;
 
   /**
-   * Marks item as visited at least once
+   * Marks item as seen at least once
    */
-  _visited?: boolean;
+  _seen?: boolean;
 
   /**
    * `true` when media couldn't be loaded

--- a/projects/gallery/src/lib/core/template-contexts.ts
+++ b/projects/gallery/src/lib/core/template-contexts.ts
@@ -4,5 +4,5 @@ export interface ItemTemplateContext {
   index: number;
   selectedIndex: number;
   item: GalleryItem;
-  visited: boolean;
+  seen: boolean;
 }


### PR DESCRIPTION
This feature improves on lazy loading. Previously, the lazy loading of an image happened only when the image was selected. That means, that upon slow swipe, you couldn't see anything from the next item, since it was not selected yet. 
The feature utilizes IntersectionObserver instead. It actually watches, how much from a given item is seen, and when over a certain threshold, loads the image (or any other media) without the need of selecting it first.